### PR TITLE
Restore use of system libvpl

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "build_pkg"]
 	path = build_pkg
 	url = https://github.com/rigaya/build_pkg.git
-[submodule "libvpl"]
-	path = libvpl
-	url = https://github.com/intel/libvpl.git

--- a/configure
+++ b/configure
@@ -514,35 +514,17 @@ else
     cnf_write "no"
 fi
 
-if [ ! -e ./buildVPL/lib/libvpl.a ]; then
-    if [ ! `type -p cmake 2> /dev/null` ]; then
-        cnf_write "cmake not found which is required to build vpl!"
-        exit 1
-    fi
-fi
-
 VPL_CFLAGS="-Os -DONEVPL_EXPERIMENTAL"
 if [ $ENABLE_DEBUG -eq 0 ] && [ $ENABLE_LTO -ne 0 ]; then
 	VPL_CFLAGS="${VPL_CFLAGS} -flto"
 fi
 
-./build_vpl.sh "${VPL_CFLAGS}"
-
-LIBVPL_LIBS=""
-if [ -e ./buildVPL/lib/libvpl.a ]; then
-    LIBVPL_LIBS="-L./buildVPL/lib -lvpl -ldl"
-elif [ -e ./buildVPL/lib64/libvpl.a ]; then
-    LIBVPL_LIBS="-L./buildVPL/lib64 -lvpl -ldl"
+if ! ${PKGCONFIG} --exists vpl ; then
+    cnf_write "vpl.pc could not be detected by ${PKGCONFIG}. [ PKG_CONFIG_PATH=${PKG_CONFIG_PATH} ]"
 else
-    cnf_write "could not find libvpl.a!"
-    exit 1
+    LIBVPL_CFLAGS=`${PKGCONFIG} --cflags vpl`
+    LIBVPL_LIBS=`${PKGCONFIG} --libs vpl`
 fi
-LIBVPL_CFLAGS="-I./libvpl/api/vpl"
-#if ! ${PKGCONFIG} --exists libvpl ; then
-#    cnf_write "libvpl could not be detected by ${PKGCONFIG}. [ PKG_CONFIG_PATH=${PKG_CONFIG_PATH} ]"
-#else
-#    LIBVPL_LIBS=`${PKGCONFIG} --libs libvpl`
-#fi
 if cxx_check "libvpl" "${CXXFLAGS} ${EXTRACXXFLAGS} ${LIBVPL_CFLAGS} ${LDFLAGS} ${EXTRALDFLAGS} ${LIBVPL_LIBS}" "" "mfxsession.h" "MFXClose(0);" ; then
     LDFLAGS="${LDFLAGS} ${LIBVPL_LIBS}"
     CXXFLAGS="${CXXFLAGS} ${LIBVPL_CFLAGS}"


### PR DESCRIPTION
The git log does not explain why libvpl was added as a submodule in the first place (43b5375c9f23ef2f3d4bebe25e50adcd19eb75c9), so I am offering a patch to restore using a system copy:

Partially undo commit 2dd81f8c6f3583a98dc1da49ba3ffca86d483802. (It is unclear why configure looked for libvpl.pc; the file has been known as vpl.pc since at least 2020.)

(A just-built version of libvpl can always be exercised with `./configure libvpl_CFLAGS=-I/home/abc/libvpl/api libvpl_LIBS="-L/home/abc/libvpl -lvpl"`.)