### PR TITLE
Some small fixes

### DIFF
--- a/.github/workflows/build_packages.yml
+++ b/.github/workflows/build_packages.yml
@@ -108,7 +108,7 @@ jobs:
         id: build_exec
         run: |
           docker run -dit --rm -v ${{ steps.prep.outputs.output_dir }}:/output -u "$(id -u):$(id -g)" --name build_pkg ${{ steps.prep.outputs.tagged_image }}
-          docker exec build_pkg sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && . ~/.cargo/env && cargo install cargo-c"
+          docker exec build_pkg sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && . ~/.cargo/env && cargo install cargo-c --locked"
           docker exec build_pkg sh -c '. ~/.cargo/env && ./configure --extra-cxxflags="-I./AviSynthPlus/avs_core/include -I./vapoursynth/include" --enable-lto'
           docker exec build_pkg make -j${{ steps.prep.outputs.nproc }}
           docker exec build_pkg ./qsvencc --version

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -26,7 +26,7 @@ if [ -e /etc/lsb-release ]; then
         PACKAGE_DEPENDS="${PACKAGE_DEPENDS},libavcodec58,libavutil56,libavformat58,libswresample3,libavfilter7,libavdevice58,libass9"
     elif [ "${PACKAGE_OS_CODENAME}" = "noble" ]; then
         PACKAGE_DEPENDS="libc6(>=2.22),libstdc++6(>=6)" 
-        PACKAGE_DEPENDS="${PACKAGE_DEPENDS},intel-media-va-driver-non-free,intel-opencl-icd,libmfx1,libmfx-gen1.2"
+        PACKAGE_DEPENDS="${PACKAGE_DEPENDS},intel-media-va-driver-non-free,intel-opencl-icd,libmfx1|libmfx-gen1.2"
         PACKAGE_DEPENDS="${PACKAGE_DEPENDS},libva-drm2,libva-x11-2,libigfxcmrt7"
         PACKAGE_DEPENDS="${PACKAGE_DEPENDS},libavcodec60,libavutil58,libavformat60,libswresample4,libavfilter9,libavdevice60,libass9"
     else

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -26,7 +26,7 @@ if [ -e /etc/lsb-release ]; then
         PACKAGE_DEPENDS="${PACKAGE_DEPENDS},libavcodec58,libavutil56,libavformat58,libswresample3,libavfilter7,libavdevice58,libass9"
     elif [ "${PACKAGE_OS_CODENAME}" = "noble" ]; then
         PACKAGE_DEPENDS="libc6(>=2.22),libstdc++6(>=6)" 
-        PACKAGE_DEPENDS="${PACKAGE_DEPENDS},intel-media-va-driver-non-free,intel-opencl-icd,libmfx1|libmfx-gen1.2"
+        PACKAGE_DEPENDS="${PACKAGE_DEPENDS},intel-media-va-driver-non-free,intel-opencl-icd,libmfx1,libmfxgen1|libmfx-gen1.2"
         PACKAGE_DEPENDS="${PACKAGE_DEPENDS},libva-drm2,libva-x11-2,libigfxcmrt7"
         PACKAGE_DEPENDS="${PACKAGE_DEPENDS},libavcodec60,libavutil58,libavformat60,libswresample4,libavfilter9,libavdevice60,libass9"
     else

--- a/docker/docker_ubuntu2404
+++ b/docker/docker_ubuntu2404
@@ -4,6 +4,17 @@ ARG DEBIAN_FRONTEND=noninteractive \
     LOCAL_USER_ID=1000 \
     LOCAL_GROUP_ID=1000
 
+RUN apt-get update &&  \
+    apt-get install -y \
+      curl \
+      wget \
+      gnupg2
+
+RUN curl -sSL https://repositories.intel.com/gpu/intel-graphics.key | \
+    gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg && \
+    echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble unified" | \
+    tee /etc/apt/sources.list.d/intel-gpu-noble.list
+
 RUN apt-get update \
     && apt install -y \
       wget \


### PR DESCRIPTION
Hello! First of all, thank you for you amazing work. Here are my 2 cents.

1. I added _--locked_ parameter to cargo-c install command to avoid problems similar to this https://github.com/rigaya/QSVEnc/actions/runs/14277645651 in the future. See https://github.com/lu-zero/cargo-c/issues/456#issuecomment-2778473643
2. I think there is a typo in package dependencies in build_deb.sh and it should be _libmfxgen1|libmfx-gen1.2_，not just _libmfx-gen1.2_, similar to 22.04
3. I think it is better to install Intel driver and some dev libs from Intel repo because this encoder is mostly used with Intel hardware