### PR TITLE
Fix clang compile

### DIFF
--- a/QSVPipeline/qsv_session.cpp
+++ b/QSVPipeline/qsv_session.cpp
@@ -316,7 +316,7 @@ mfxStatus MFXVideoSession2::initHW(mfxIMPL& impl, const QSVDeviceNum dev) {
                 impl_desc->Dev.MediaAdapterType == MFX_MEDIA_INTEGRATED ? _T("i") : _T("d"),
                 char_to_tstring((const char *)impl_desc->Dev.DeviceID).c_str(), impl_desc->Dev.NumSubDevices);
             for (uint32_t i = 0; i < impl_desc->Dev.NumSubDevices; i++) {
-                devDesc += strsprintf(_T(" (Sub %d: %s)"), impl_desc->Dev.SubDevices[i].Index, char_to_tstring((const char *)impl_desc->Dev.SubDevices[i].SubDeviceID));
+                devDesc += strsprintf(_T(" (Sub %d: %s)"), impl_desc->Dev.SubDevices[i].Index, char_to_tstring((const char *)impl_desc->Dev.SubDevices[i].SubDeviceID).c_str());
             }
 
             const mfxAccelerationMode acc = impl_desc->AccelerationMode;


### PR DESCRIPTION
* error: cannot pass object of non-trivial type 'tstring' (aka 'basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs]